### PR TITLE
Melhoria de usabilidade/estabilidade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ serde_repr = { version = "0.1.7" }
 serde_json = { version = "1.0.64" }
 log = { version = "0.4.14" }
 futures = { version = "0.3.15" }
+lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,3 @@ serde_repr = { version = "0.1.7" }
 serde_json = { version = "1.0.64" }
 log = { version = "0.4.14" }
 futures = { version = "0.3.15" }
-lazy_static = "1.4.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,57 +1,88 @@
+use std::{thread, time::Duration};
+
+use isahc::{config::Configurable, Request, RequestExt};
+
+use log::{Metadata, Record};
+
+use crate::prelude::{VioletLog, VioletLogSeverity};
 pub type GenericError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub type GResult<T> = Result<T, GenericError>;
 
-pub(self) mod static_data {
-    use lazy_static::lazy_static;
-    use std::{any::Any, collections::HashMap, sync::Mutex};
+#[derive(Clone)]
+struct HttpVioletData {
+    indetifier: u64,
+    token: String,
+}
 
-    use super::GResult;
-
-    lazy_static! {
-        static ref STORAGE_STATIC: Mutex<StaticData> = StaticData::new();
+impl HttpVioletData {
+    fn new(indetifier: u64, token: String) -> Self {
+        Self { indetifier, token }
     }
 
-    pub struct StaticData {
-        data: HashMap<String, Box<dyn Any + Send + Sync>>,
+    async fn send_data(
+        &self,
+        title: String,
+        severity: VioletLogSeverity,
+        message: String,
+    ) -> GResult<()> {
+        let log_vio = VioletLog::new(severity, title, message);
+        let log_vio_json = serde_json::to_string(&log_vio)?;
+
+        let retorno = Request::post(format!(
+            "https://violet.zuraaa.com/api/apps/{}/events",
+            self.indetifier
+        ))
+        .header("Content-Type", "application/json")
+        .header("Authorization", &self.token)
+        .timeout(Duration::from_secs(20))
+        .body(log_vio_json)?
+        .send_async()
+        .await?;
+        let body = retorno.status();
+        println!("{:?}", body);
+        Ok(())
+    }
+}
+
+pub fn init(indentifier: u64, token: String) {
+    static mut HAS_INIT: bool = false;
+
+    unsafe {
+        if HAS_INIT {
+            return;
+        }
     }
 
-    impl StaticData {
-        fn new() -> Mutex<Self> {
-            let data = Self {
-                data: HashMap::new(),
-            };
+    let leak_content: &'static mut HttpVioletData =
+        Box::leak(Box::new(HttpVioletData::new(indentifier, token)));
 
-            Mutex::new(data)
-        }
+    log::set_logger(leak_content).unwrap();
 
-        fn set_data_value(&mut self, name: String, data: impl Any + Send + Sync) {
-            if let Some(mapped) = self.data.get_mut(&name) {
-                *mapped = Box::new(data);
-            } else {
-                self.data.insert(name, Box::new(data));
-            }
-        }
+    unsafe {
+        HAS_INIT = true;
+    }
+}
 
-        pub fn add_element_to_static(name: String, data: impl Any + Send + Sync) -> GResult<()> {
-            let mut locked_data = STORAGE_STATIC.lock().map_err(|why| format!("{:?}", why))?;
-            locked_data.set_data_value(name, data);
-            Ok(())
-        }
+impl log::Log for HttpVioletData {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
 
-        pub fn get_data_elemet_static<T: 'static, F>(name: &str, callback: F) -> GResult<()>
-        where
-            F: Fn(&T),
-        {
-            let locked_data = STORAGE_STATIC.lock().map_err(|why| format!("{:?}", why))?;
-            let data = locked_data
-                .data
-                .get(name)
-                .ok_or("Key não possui dados")?
-                .downcast_ref::<T>()
-                .ok_or("Downcast não pode inferir esse tipo")?;
+    fn flush(&self) {
+        todo!()
+    }
 
-            callback(data);
-            Ok(())
-        }
+    fn log(&self, record: &Record) {
+        let cloned_self = self.clone();
+        let pointer_data = (record.level(), record.args().to_string());
+
+        thread::spawn(move || {
+            futures::executor::block_on(async {
+                cloned_self
+                    .send_data("vulcan gay".into(), pointer_data.0.into(), pointer_data.1)
+                    .await
+                    .unwrap();
+            });
+        });
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -97,6 +97,8 @@ impl log::Log for HttpVioletData {
     fn flush(&self) {
         todo!()
     }
+
+    fn log(&self, record: &Record) {
         let pointer_data = (record.level(), record.args().to_string());
 
         if self.config.send_err_async {
@@ -126,3 +128,4 @@ impl log::Log for HttpVioletData {
         }
     }
 }
+

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,19 +4,66 @@ use isahc::{config::Configurable, Request, RequestExt};
 
 use log::{Metadata, Record};
 
-use crate::prelude::{VioletLog, VioletLogSeverity};
+use crate::{VioletLog, VioletLogSeverity};
 pub type GenericError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub type GResult<T> = Result<T, GenericError>;
 
 #[derive(Clone)]
 struct HttpVioletData {
-    indetifier: u64,
+    config: VioletBuilder,
+}
+
+#[derive(Debug, Clone)]
+pub struct VioletBuilder {
+    indentifier: u64,
     token: String,
+    send_err_async: bool,
+    default_title: String,
+}
+
+impl VioletBuilder {
+    pub fn new(token: impl AsRef<str>, indentifier: u64) -> Self {
+        Self {
+            token: token.as_ref().to_string(),
+            indentifier,
+            default_title: env!("CARGO_PKG_NAME").into(),
+            send_err_async: false,
+        }
+    }
+
+    pub fn enable_async(mut self) -> Self {
+        self.send_err_async = true;
+        self
+    }
+
+    pub fn set_title(mut self, title: impl AsRef<str>) -> Self {
+        self.default_title = title.as_ref().to_string();
+        self
+    }
+
+    pub fn init(self) {
+        static mut HAS_INIT: bool = false;
+
+        unsafe {
+            if HAS_INIT {
+                return;
+            }
+        }
+
+        let leak_content: &'static mut HttpVioletData =
+            Box::leak(Box::new(HttpVioletData::new(self)));
+
+        log::set_logger(leak_content).unwrap();
+
+        unsafe {
+            HAS_INIT = true;
+        }
+    }
 }
 
 impl HttpVioletData {
-    fn new(indetifier: u64, token: String) -> Self {
-        Self { indetifier, token }
+    fn new(config: VioletBuilder) -> Self {
+        Self { config }
     }
 
     async fn send_data(
@@ -30,10 +77,10 @@ impl HttpVioletData {
 
         let retorno = Request::post(format!(
             "https://violet.zuraaa.com/api/apps/{}/events",
-            self.indetifier
+            self.config.indentifier
         ))
         .header("Content-Type", "application/json")
-        .header("Authorization", &self.token)
+        .header("Authorization", &self.config.token)
         .timeout(Duration::from_secs(20))
         .body(log_vio_json)?
         .send_async()
@@ -41,25 +88,6 @@ impl HttpVioletData {
         let body = retorno.status();
         println!("{:?}", body);
         Ok(())
-    }
-}
-
-pub fn init(indentifier: u64, token: String) {
-    static mut HAS_INIT: bool = false;
-
-    unsafe {
-        if HAS_INIT {
-            return;
-        }
-    }
-
-    let leak_content: &'static mut HttpVioletData =
-        Box::leak(Box::new(HttpVioletData::new(indentifier, token)));
-
-    log::set_logger(leak_content).unwrap();
-
-    unsafe {
-        HAS_INIT = true;
     }
 }
 
@@ -73,16 +101,32 @@ impl log::Log for HttpVioletData {
     }
 
     fn log(&self, record: &Record) {
-        let cloned_self = self.clone();
         let pointer_data = (record.level(), record.args().to_string());
 
-        thread::spawn(move || {
-            futures::executor::block_on(async {
-                cloned_self
-                    .send_data("vulcan gay".into(), pointer_data.0.into(), pointer_data.1)
-                    .await
-                    .unwrap();
+        if self.config.send_err_async {
+            let cloned_self = self.clone();
+            thread::spawn(move || {
+                futures::executor::block_on(async {
+                    cloned_self
+                        .send_data(
+                            cloned_self.config.default_title.clone(),
+                            pointer_data.0.into(),
+                            pointer_data.1,
+                        )
+                        .await
+                        .ok();
+                });
             });
-        });
+        } else {
+            futures::executor::block_on(async {
+                self.send_data(
+                    self.config.default_title.clone(),
+                    pointer_data.0.into(),
+                    pointer_data.1,
+                )
+                .await
+                .ok();
+            })
+        }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,95 +1,57 @@
-use std::{error::Error, thread::{self, spawn}};
+pub type GenericError = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub type GResult<T> = Result<T, GenericError>;
 
-use isahc::{AsyncBody, HttpClient, Response};
-use log::{Level, Log, Metadata, Record, info, set_logger, set_max_level};
-use serde_json::to_string;
+pub(self) mod static_data {
+    use lazy_static::lazy_static;
+    use std::{any::Any, collections::HashMap, sync::Mutex};
 
-use crate::log::{VioletLog, VioletLogSeverity};
+    use super::GResult;
 
-pub struct VioletMail {
-    base_url: String,
-    client: HttpClient
-}
-
-static mut VIOLET_INITIALIZED: bool = false;
-
-pub type VioletError = Box<dyn Error + Send + Sync + 'static>;
-
-impl VioletMail {
-    pub fn init(identifier: u32, token: &str) -> Result<&'static Self, VioletError> {
-        unsafe {
-            if !VIOLET_INITIALIZED {
-                let client = HttpClient::builder()
-                    .default_header("Authorization", token)
-                    .default_header("Content-Type", "application/json")
-                    .build()?;
-        
-                let base_url = format!("https://violet.zuraaa.com/api/apps/{}/events", identifier);
-        
-                let violet_mail = Box::new(Self {
-                    client,
-                    base_url
-                });
-        
-                let violet_leak: &'static VioletMail = Box::leak(violet_mail); 
-        
-                set_logger(violet_leak).map_err(|err|
-                    format!("{:?}", err)
-                )?;
-                set_max_level(log::LevelFilter::Trace);
-        
-                Ok(violet_leak)
-            } else {
-                Err("Violet mail ja iniciado".into())
-            }
-        }
+    lazy_static! {
+        static ref STORAGE_STATIC: Mutex<StaticData> = StaticData::new();
     }
 
-    pub fn send_log(&self, violet_log: &VioletLog) {
-        let body = to_string(violet_log);
+    pub struct StaticData {
+        data: HashMap<String, Box<dyn Any + Send + Sync>>,
+    }
 
-        let client = &self.client;
-        let base_url = &self.base_url;
-
-        let handle = spawn(move || {
-            let future = async {
-                client.post_async(base_url, body.unwrap()).await
+    impl StaticData {
+        fn new() -> Mutex<Self> {
+            let data = Self {
+                data: HashMap::new(),
             };
 
-            futures::executor::block_on(future)
-        });
+            Mutex::new(data)
+        }
 
+        fn set_data_value(&mut self, name: String, data: impl Any + Send + Sync) {
+            if let Some(mapped) = self.data.get_mut(&name) {
+                *mapped = Box::new(data);
+            } else {
+                self.data.insert(name, Box::new(data));
+            }
+        }
+
+        pub fn add_element_to_static(name: String, data: impl Any + Send + Sync) -> GResult<()> {
+            let mut locked_data = STORAGE_STATIC.lock().map_err(|why| format!("{:?}", why))?;
+            locked_data.set_data_value(name, data);
+            Ok(())
+        }
+
+        pub fn get_data_elemet_static<T: 'static, F>(name: &str, callback: F) -> GResult<()>
+        where
+            F: Fn(&T),
+        {
+            let locked_data = STORAGE_STATIC.lock().map_err(|why| format!("{:?}", why))?;
+            let data = locked_data
+                .data
+                .get(name)
+                .ok_or("Key não possui dados")?
+                .downcast_ref::<T>()
+                .ok_or("Downcast não pode inferir esse tipo")?;
+
+            callback(data);
+            Ok(())
+        }
     }
 }
-
-impl Log for VioletMail {
-    fn enabled(&self, _: &Metadata) -> bool {
-        true
-    }
-
-    fn log(&self, record: &Record) {
-        println!("{} - {}", record.level(), record.args());
-
-        let violet_log = VioletLog::new(
-            VioletLogSeverity::from(record.level()), 
-            "Violet mail".to_string(), 
-            record.args().to_string()
-        );
-
-        self.send_log(&violet_log);
-    }
-
-    fn flush(&self) {
-        todo!()
-    }
-}
-
-// pub trait SendToVioletMail {
-//     fn send_to_violet();
-// }
-
-// impl SendToVioletMail for dyn Error {
-//     fn send_to_violet() {
-//         todo!()
-//     }
-// }

--- a/src/client.rs
+++ b/src/client.rs
@@ -75,7 +75,7 @@ impl HttpVioletData {
         let log_vio = VioletLog::new(severity, title, message);
         let log_vio_json = serde_json::to_string(&log_vio)?;
 
-        let retorno = Request::post(format!(
+        Request::post(format!(
             "https://violet.zuraaa.com/api/apps/{}/events",
             self.config.indentifier
         ))
@@ -85,8 +85,6 @@ impl HttpVioletData {
         .body(log_vio_json)?
         .send_async()
         .await?;
-        let body = retorno.status();
-        println!("{:?}", body);
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,7 @@
 pub mod client;
 pub mod log;
+
+pub mod prelude {
+    pub use super::client::*;
+    pub use super::log::*;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
-pub mod client;
-pub mod log;
+mod client;
+mod log;
 
-pub mod prelude {
-    pub use super::client::*;
-    pub use super::log::*;
-}
+pub use crate::log::*;
+pub use client::*;


### PR DESCRIPTION
Foi melhorado a usabilidade, tirando a função init e substituindo por um builder, que permite algumas configurações

Foi testado se existe memory leak

Adicionado uma versão sincrona do envio para projetos que tem baixa espectativa de vida

Adicionado customização do title

e movido virtualmente todos os pubs para o root do crate, (para facilitar os imports