### PR TITLE
log and send level filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ serde_repr = { version = "0.1.7" }
 serde_json = { version = "1.0.64" }
 log = { version = "0.4.14" }
 futures = { version = "0.3.15" }
+chrono = "0.4.19"

--- a/src/log.rs
+++ b/src/log.rs
@@ -3,14 +3,14 @@ use serde::Serialize;
 use serde_repr::Serialize_repr;
 
 #[derive(Serialize)]
-pub struct VioletLog {
+pub(crate) struct VioletLog {
     severity: VioletLogSeverity,
     title: String,
     message: String,
-    stacktrace: Option<String>
+    stacktrace: Option<String>,
 }
 
-#[derive(Serialize_repr)]
+#[derive(Debug, Clone, Serialize_repr)]
 #[repr(u8)]
 pub enum VioletLogSeverity {
     NoDefined = 0,
@@ -18,7 +18,7 @@ pub enum VioletLogSeverity {
     Error = 2,
     Warning = 3,
     Info = 4,
-    Verbose = 5
+    Verbose = 5,
 }
 
 impl VioletLog {
@@ -27,15 +27,15 @@ impl VioletLog {
             severity,
             title,
             message,
-            stacktrace: None
+            stacktrace: None,
         }
     }
 
-    pub fn set_stacktrace(&mut self, stacktrace: String) {
-        self.stacktrace = Some(stacktrace);
-    }
+    // Com a mudança para pub(crate) essa função não possui uso.
+    // pub fn set_stacktrace(&mut self, stacktrace: String) {
+    //     self.stacktrace = Some(stacktrace);
+    // }
 }
-
 
 impl From<u8> for VioletLogSeverity {
     fn from(el: u8) -> Self {
@@ -45,20 +45,20 @@ impl From<u8> for VioletLogSeverity {
             3 => VioletLogSeverity::Warning,
             4 => VioletLogSeverity::Info,
             5 => VioletLogSeverity::Verbose,
-            _ => VioletLogSeverity::NoDefined
+            _ => VioletLogSeverity::NoDefined,
         }
     }
 }
 
-impl From<VioletLogSeverity> for u8 {
-    fn from(val: VioletLogSeverity) -> Self {
+impl From<&VioletLogSeverity> for u8 {
+    fn from(val: &VioletLogSeverity) -> Self {
         match val {
             VioletLogSeverity::NoDefined => 0,
             VioletLogSeverity::Severe => 1,
             VioletLogSeverity::Error => 2,
             VioletLogSeverity::Warning => 3,
             VioletLogSeverity::Info => 4,
-            VioletLogSeverity::Verbose => 5
+            VioletLogSeverity::Verbose => 5,
         }
     }
 }
@@ -73,4 +73,26 @@ impl From<Level> for VioletLogSeverity {
             Level::Trace => VioletLogSeverity::NoDefined,
         }
     }
+}
+
+pub(crate) fn convert_level_to_u8(level: &Level) -> u8 {
+    match level {
+        Level::Error => 2,
+        Level::Warn => 3,
+        Level::Info => 4,
+        Level::Debug => 5,
+        Level::Trace => 0,
+    }
+}
+
+pub(crate) fn convert_level_to_string(level: &Level) -> String {
+    let matc = match level {
+        Level::Error => "ERRO",
+        Level::Warn => "WARN",
+        Level::Info => "INFO",
+        Level::Debug => "DEBU",
+        Level::Trace => "TRAC",
+    };
+
+    matc.into()
 }


### PR DESCRIPTION
Adicionado micro sistema de level para separar log de console de log para violet,
Adicionado um simple console log,
Removido algumas structs de pub para pub(crate)
Adicionado mais conversores para log::Level
