### PR TITLE
Acessibilidade do VioletHttpClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,11 @@ keywords = ["violet", "mail", "log", "error-handling", "http-api"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-isahc = { version = "1.4.0", features = ["json"] }
-serde = { version = "1.0.126", features = ["derive"] }
-serde_repr = { version = "0.1.7" }
-serde_json = { version = "1.0.64" }
-log = { version = "0.4.14" }
-futures = { version = "0.3.15" }
+isahc = { version="1.4.0", features=["json"] }
+serde = { version="1.0.126", features=["derive"] }
+serde_repr = { version="0.1.7" }
+serde_json = { version="1.0.64" }
+log = { version="0.4.14" }
+futures = { version="0.3.15" }
 chrono = "0.4.19"
+lazy_static = "1.4.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -111,7 +111,7 @@ impl HttpVioletData {
             .ok_or("Violet não foi inicializada")?
             .clone();
         println!("{:?}", &log_vio_json);
-        let aaa = Request::post(format!(
+        Request::post(format!(
             "https://violet.zuraaa.com/api/apps/{}/events",
             config.indentifier
         ))

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,17 +1,25 @@
-use std::{thread, time::Duration};
+use std::{
+    sync::{Arc, RwLock},
+    thread,
+    time::Duration,
+};
 
 use chrono::Utc;
 use isahc::{config::Configurable, Request, RequestExt};
 
-use log::{Metadata, Record};
+use log::{set_logger, Metadata, Record};
 
 use crate::{VioletLog, VioletLogSeverity};
 pub type GenericError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub type GResult<T> = Result<T, GenericError>;
 
+lazy_static::lazy_static! {
+    static ref CLIENT: HttpVioletData = HttpVioletData::new();
+}
+
 #[derive(Clone)]
 struct HttpVioletData {
-    config: VioletBuilder,
+    config: Arc<RwLock<Option<VioletBuilder>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -49,29 +57,36 @@ impl VioletBuilder {
         self
     }
 
-    pub fn init(self) {
-        static mut HAS_INIT: bool = false;
-
-        unsafe {
-            if HAS_INIT {
-                return;
-            }
+    pub fn init(self) -> GResult<()> {
+        if CLIENT
+            .config
+            .read()
+            .map_err(|err| format!("Poisoded mutex here: {:?}", &err))?
+            .is_some()
+        {
+            return Ok(());
         }
 
-        let leak_content: &'static mut HttpVioletData =
-            Box::leak(Box::new(HttpVioletData::new(self)));
+        CLIENT.set_config(self)?;
+        set_logger(&*CLIENT).unwrap();
 
-        log::set_logger(leak_content).unwrap();
-
-        unsafe {
-            HAS_INIT = true;
-        }
+        Ok(())
     }
 }
 
 impl HttpVioletData {
-    fn new(config: VioletBuilder) -> Self {
-        Self { config }
+    fn new() -> Self {
+        Self {
+            config: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    fn set_config(&self, config: VioletBuilder) -> GResult<()> {
+        *self
+            .config
+            .write()
+            .map_err(|err| format!("Mutex is poisoned: {:?}", err))? = Some(config);
+        Ok(())
     }
 
     async fn send_data(
@@ -82,13 +97,21 @@ impl HttpVioletData {
     ) -> GResult<()> {
         let log_vio = VioletLog::new(severity, title, message);
         let log_vio_json = serde_json::to_string(&log_vio)?;
+        let config = self
+            .config
+            .clone()
+            .read()
+            .map_err(|err| format!("Poisoned mutex: {:?}", err))?
+            .as_ref()
+            .ok_or("Violet não foi inicializada")?
+            .clone();
 
         Request::post(format!(
             "https://violet.zuraaa.com/api/apps/{}/events",
-            self.config.indentifier
+            config.indentifier
         ))
         .header("Content-Type", "application/json")
-        .header("Authorization", &self.config.token)
+        .header("Authorization", config.token)
         .timeout(Duration::from_secs(20))
         .body(log_vio_json)?
         .send_async()
@@ -107,6 +130,19 @@ impl log::Log for HttpVioletData {
     }
 
     fn log(&self, record: &Record) {
+        if self.config.read().unwrap().is_none() {
+            panic!("Violet não foi inicializado");
+        }
+
+        let config = self
+            .config
+            .read()
+            .as_ref()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .clone();
+
         let pointer_data = (record.level(), record.args().to_string());
 
         {
@@ -117,36 +153,28 @@ impl log::Log for HttpVioletData {
         }
 
         {
-            let level_u8 = u8::from(&self.config.send_level);
+            let level_u8 = u8::from(config.send_level.clone());
             let level_event_u8 = crate::convert_level_to_u8(&pointer_data.0);
             if level_event_u8 > level_u8 {
                 return;
             }
         }
 
-        if self.config.send_err_async {
+        if config.send_err_async {
             let cloned_self = self.clone();
             thread::spawn(move || {
                 futures::executor::block_on(async {
                     cloned_self
-                        .send_data(
-                            cloned_self.config.default_title.clone(),
-                            pointer_data.0.into(),
-                            pointer_data.1,
-                        )
+                        .send_data(config.default_title, pointer_data.0.into(), pointer_data.1)
                         .await
                         .ok();
                 });
             });
         } else {
             futures::executor::block_on(async {
-                self.send_data(
-                    self.config.default_title.clone(),
-                    pointer_data.0.into(),
-                    pointer_data.1,
-                )
-                .await
-                .ok();
+                self.send_data(config.default_title, pointer_data.0.into(), pointer_data.1)
+                    .await
+                    .ok();
             })
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,7 +18,8 @@ lazy_static::lazy_static! {
 }
 
 #[derive(Clone)]
-struct HttpVioletData {
+#[non_exhaustive]
+pub struct HttpVioletData {
     config: Arc<RwLock<Option<VioletBuilder>>>,
 }
 
@@ -81,6 +82,10 @@ impl HttpVioletData {
         }
     }
 
+    pub fn get_http() -> &'static Self {
+        &CLIENT
+    }
+
     fn set_config(&self, config: VioletBuilder) -> GResult<()> {
         *self
             .config
@@ -89,7 +94,7 @@ impl HttpVioletData {
         Ok(())
     }
 
-    async fn send_data(
+    pub async fn send_data(
         &self,
         title: String,
         severity: VioletLogSeverity,
@@ -105,8 +110,8 @@ impl HttpVioletData {
             .as_ref()
             .ok_or("Violet não foi inicializada")?
             .clone();
-
-        Request::post(format!(
+        println!("{:?}", &log_vio_json);
+        let aaa = Request::post(format!(
             "https://violet.zuraaa.com/api/apps/{}/events",
             config.indentifier
         ))
@@ -116,6 +121,8 @@ impl HttpVioletData {
         .body(log_vio_json)?
         .send_async()
         .await?;
+
+        println!("{}", aaa.status());
         Ok(())
     }
 }
@@ -174,7 +181,7 @@ impl log::Log for HttpVioletData {
             futures::executor::block_on(async {
                 self.send_data(config.default_title, pointer_data.0.into(), pointer_data.1)
                     .await
-                    .ok();
+                    .expect("fudeu")
             })
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -121,8 +121,6 @@ impl HttpVioletData {
         .body(log_vio_json)?
         .send_async()
         .await?;
-
-        println!("{}", aaa.status());
         Ok(())
     }
 }
@@ -181,7 +179,7 @@ impl log::Log for HttpVioletData {
             futures::executor::block_on(async {
                 self.send_data(config.default_title, pointer_data.0.into(), pointer_data.1)
                     .await
-                    .expect("fudeu")
+                    .ok();
             })
         }
     }

--- a/src/log.rs
+++ b/src/log.rs
@@ -50,8 +50,8 @@ impl From<u8> for VioletLogSeverity {
     }
 }
 
-impl From<&VioletLogSeverity> for u8 {
-    fn from(val: &VioletLogSeverity) -> Self {
+impl From<VioletLogSeverity> for u8 {
+    fn from(val: VioletLogSeverity) -> Self {
         match val {
             VioletLogSeverity::NoDefined => 0,
             VioletLogSeverity::Severe => 1,


### PR DESCRIPTION
- Removido o Box::leak
- Criado uma static para armazenar o VioletHttpClient atual
- configurado todos os erros de verificação se Violet n foi iniciada
- adicionado metodo get_http() para pegar a referencia de VioletHttpClient
- send agr eh publico assim como VioletHttpClient